### PR TITLE
fix:Upgrade idna to 1.0.3 to avoid CVE-2024-12224

### DIFF
--- a/.github/workflows/ci-version.yml
+++ b/.github/workflows/ci-version.yml
@@ -58,7 +58,7 @@ jobs:
     name: Test ${{ matrix.toolchain }} on ${{ matrix.os }} (${{ matrix.features }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -113,7 +113,7 @@ jobs:
     name: Test ${{ matrix.toolchain }} on ${{ matrix.os }} (${{ matrix.features }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
@@ -19,7 +19,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
@@ -74,7 +74,7 @@ jobs:
     name: Test ${{ matrix.toolchain }} on ${{ matrix.os }} (${{ matrix.features }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -129,7 +129,7 @@ jobs:
     name: Test ${{ matrix.toolchain }} on ${{ matrix.os }} (${{ matrix.features }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/validators-derive/Cargo.toml
+++ b/validators-derive/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro2 = "1"
 
 enum-ordinalize = { version = "4.2", default-features = false, features = ["derive"] }
 
-educe = { version = "0.5", default-features = false, features = ["Debug"], optional = true }
+educe = { version = "0.6", default-features = false, features = ["Debug"], optional = true }
 phonenumber = { version = "0.3", optional = true }
 regex = { version = "1", optional = true }
 

--- a/validators-derive/src/panic.rs
+++ b/validators-derive/src/panic.rs
@@ -65,9 +65,7 @@ pub(crate) fn unsupported_validator(name: &Path) -> syn::Error {
 
             syn::Error::new(
                 span,
-                format!(
-                    "unsupported validator `{name}`, available validators:{DisplayValidators}"
-                ),
+                format!("unsupported validator `{name}`, available validators:{DisplayValidators}"),
             )
         },
     }

--- a/validators-derive/src/panic.rs
+++ b/validators-derive/src/panic.rs
@@ -58,7 +58,7 @@ pub(crate) fn unsupported_validator(name: &Path) -> syn::Error {
     match name.get_ident() {
         Some(name) => syn::Error::new(
             span,
-            format!("unsupported validator `{name}`, available validators:{}", DisplayValidators),
+            format!("unsupported validator `{name}`, available validators:{DisplayValidators}"),
         ),
         None => {
             let name = path_to_string(name);
@@ -66,8 +66,7 @@ pub(crate) fn unsupported_validator(name: &Path) -> syn::Error {
             syn::Error::new(
                 span,
                 format!(
-                    "unsupported validator `{name}`, available validators:{}",
-                    DisplayValidators
+                    "unsupported validator `{name}`, available validators:{DisplayValidators}"
                 ),
             )
         },

--- a/validators-derive/src/validator_handlers/base32/mod.rs
+++ b/validators-derive/src/validator_handlers/base32/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct Base32Handler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/base32_decoded/mod.rs
+++ b/validators-derive/src/validator_handlers/base32_decoded/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 pub(crate) struct Base32DecodedHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::VecU8);

--- a/validators-derive/src/validator_handlers/base64/mod.rs
+++ b/validators-derive/src/validator_handlers/base64/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct Base64Handler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/base64_decoded/mod.rs
+++ b/validators-derive/src/validator_handlers/base64_decoded/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 pub(crate) struct Base64DecodedHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::VecU8);

--- a/validators-derive/src/validator_handlers/base64_url/mod.rs
+++ b/validators-derive/src/validator_handlers/base64_url/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct Base64UrlHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/base64_url_decoded/mod.rs
+++ b/validators-derive/src/validator_handlers/base64_url_decoded/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 pub(crate) struct Base64UrlDecodedHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::VecU8);

--- a/validators-derive/src/validator_handlers/bit/mod.rs
+++ b/validators-derive/src/validator_handlers/bit/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct BitHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Bit);

--- a/validators-derive/src/validator_handlers/boolean/mod.rs
+++ b/validators-derive/src/validator_handlers/boolean/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct BooleanHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Boolean);

--- a/validators-derive/src/validator_handlers/byte/mod.rs
+++ b/validators-derive/src/validator_handlers/byte/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct ByteHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Bit);

--- a/validators-derive/src/validator_handlers/domain/mod.rs
+++ b/validators-derive/src/validator_handlers/domain/mod.rs
@@ -14,10 +14,12 @@ use crate::{
 pub(crate) struct DomainHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowLocal {
     domain:   TypeEnum,
     is_local: TypeEnum,
@@ -25,6 +27,7 @@ pub struct StructAllowLocal {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPort {
     domain: TypeEnum,
     port:   TypeEnum,
@@ -32,6 +35,7 @@ pub struct StructAllowPort {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPortAllowLocal {
     domain:   TypeEnum,
     is_local: TypeEnum,
@@ -40,6 +44,7 @@ pub struct StructAllowPortAllowLocal {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowIPv4 {
     domain:  TypeEnum,
     is_ipv4: TypeEnum,
@@ -47,6 +52,7 @@ pub struct StructAllowIPv4 {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowIPv4AllowLocal {
     domain:   TypeEnum,
     is_ipv4:  TypeEnum,
@@ -55,6 +61,7 @@ pub struct StructAllowIPv4AllowLocal {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowIPv4AllowPort {
     domain:  TypeEnum,
     is_ipv4: TypeEnum,
@@ -63,6 +70,7 @@ pub struct StructAllowIPv4AllowPort {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowIPv4AllowPortAllowLocal {
     domain:   TypeEnum,
     is_ipv4:  TypeEnum,

--- a/validators-derive/src/validator_handlers/host/mod.rs
+++ b/validators-derive/src/validator_handlers/host/mod.rs
@@ -14,10 +14,12 @@ use crate::{
 pub(crate) struct HostHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowLocal {
     host:     TypeEnum,
     is_local: TypeEnum,
@@ -25,6 +27,7 @@ pub struct StructAllowLocal {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPort {
     host: TypeEnum,
     port: TypeEnum,
@@ -32,6 +35,7 @@ pub struct StructAllowPort {
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPortAllowLocal {
     host:     TypeEnum,
     is_local: TypeEnum,

--- a/validators-derive/src/validator_handlers/ip/mod.rs
+++ b/validators-derive/src/validator_handlers/ip/mod.rs
@@ -13,10 +13,12 @@ use crate::{
 pub(crate) struct IpHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPort {
     ip:   TypeEnum,
     port: TypeEnum,

--- a/validators-derive/src/validator_handlers/ipv4/mod.rs
+++ b/validators-derive/src/validator_handlers/ipv4/mod.rs
@@ -13,10 +13,12 @@ use crate::{
 pub(crate) struct Ipv4Handler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPort {
     ipv4: TypeEnum,
     port: TypeEnum,

--- a/validators-derive/src/validator_handlers/ipv6/mod.rs
+++ b/validators-derive/src/validator_handlers/ipv6/mod.rs
@@ -13,10 +13,12 @@ use crate::{
 pub(crate) struct Ipv6Handler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 #[derive(Educe)]
 #[educe(Debug(name = "Struct"))]
+#[allow(dead_code)] // Used for parsing
 pub struct StructAllowPort {
     ipv6: TypeEnum,
     port: TypeEnum,

--- a/validators-derive/src/validator_handlers/json/mod.rs
+++ b/validators-derive/src/validator_handlers/json/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct JsonHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Serde);

--- a/validators-derive/src/validator_handlers/length/mod.rs
+++ b/validators-derive/src/validator_handlers/length/mod.rs
@@ -10,6 +10,7 @@ use crate::{common::type_enum::TypeEnum, panic};
 pub(crate) struct LengthHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::CollectionLength);

--- a/validators-derive/src/validator_handlers/line/mod.rs
+++ b/validators-derive/src/validator_handlers/line/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct LineHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/mac_address/mod.rs
+++ b/validators-derive/src/validator_handlers/mac_address/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct MacAddressHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::U64);

--- a/validators-derive/src/validator_handlers/number/mod.rs
+++ b/validators-derive/src/validator_handlers/number/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct NumberHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Number);

--- a/validators-derive/src/validator_handlers/phone/mod.rs
+++ b/validators-derive/src/validator_handlers/phone/mod.rs
@@ -12,6 +12,7 @@ use crate::{common::type_enum::TypeEnum, panic};
 pub(crate) struct PhoneHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/regex/mod.rs
+++ b/validators-derive/src/validator_handlers/regex/mod.rs
@@ -10,6 +10,7 @@ use crate::{common::type_enum::TypeEnum, panic};
 pub(crate) struct RegexHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/regex/regex_attribute.rs
+++ b/validators-derive/src/validator_handlers/regex/regex_attribute.rs
@@ -103,7 +103,7 @@ impl RegexAttribute {
                 rocket_options,
             })
         } else {
-            return Err(syn::Error::new(meta.path().span(), "the `regex` parameter is not set"));
+            Err(syn::Error::new(meta.path().span(), "the `regex` parameter is not set"))
         }
     }
 }

--- a/validators-derive/src/validator_handlers/semver/mod.rs
+++ b/validators-derive/src/validator_handlers/semver/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct SemverHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Version);

--- a/validators-derive/src/validator_handlers/semver_req/mod.rs
+++ b/validators-derive/src/validator_handlers/semver_req/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct SemverReqHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::VersionReq);

--- a/validators-derive/src/validator_handlers/signed_integer/mod.rs
+++ b/validators-derive/src/validator_handlers/signed_integer/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct SignedIntegerHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::SignedInteger);

--- a/validators-derive/src/validator_handlers/text/mod.rs
+++ b/validators-derive/src/validator_handlers/text/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct TextHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::String);

--- a/validators-derive/src/validator_handlers/unsigned_integer/mod.rs
+++ b/validators-derive/src/validator_handlers/unsigned_integer/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct UnsignedIntegerHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::SignedInteger);

--- a/validators-derive/src/validator_handlers/url/mod.rs
+++ b/validators-derive/src/validator_handlers/url/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) struct UrlHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::Url);

--- a/validators-derive/src/validator_handlers/uuid/mod.rs
+++ b/validators-derive/src/validator_handlers/uuid/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) struct UuidHandler;
 
 #[derive(Debug)]
+#[allow(dead_code)] // Used for parsing
 pub struct Struct(TypeEnum);
 
 const ITEM: Struct = Struct(TypeEnum::U128);

--- a/validators/Cargo.toml
+++ b/validators/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 validators-derive = { version = "0.25", path = "../validators-derive", optional = true }
 
 data-encoding = { version = "2.5", default-features = false, features = ["alloc"], optional = true }
-idna = { version = "1.1", default-features = false, features = ["alloc"], optional = true }
+idna = { version = "1.1", default-features = false, features = ["alloc","compiled_data"], optional = true }
 byte-unit = { version = "5.1", default-features = false, optional = true }
 url-dep = { package = "url", version = "2", optional = true }
 str-utils = { version = "0.1", optional = true }

--- a/validators/Cargo.toml
+++ b/validators/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 validators-derive = { version = "0.25", path = "../validators-derive", optional = true }
 
 data-encoding = { version = "2.5", default-features = false, features = ["alloc"], optional = true }
-idna = { version = "0.5", default-features = false, features = ["alloc"], optional = true }
+idna = { version = "1.1", default-features = false, features = ["alloc"], optional = true }
 byte-unit = { version = "5.1", default-features = false, optional = true }
 url-dep = { package = "url", version = "2", optional = true }
 str-utils = { version = "0.1", optional = true }

--- a/validators/src/traits/to_uri_authority_string.rs
+++ b/validators/src/traits/to_uri_authority_string.rs
@@ -3,5 +3,5 @@ use alloc::borrow::Cow;
 /// The `domain`, `host`, `ip`, `ipv4`, `ipv6` validators will implement this for their types.
 pub trait ToUriAuthorityString {
     /// Retrieve the URI authority as a string.
-    fn to_uri_authority_string(&self) -> Cow<str>;
+    fn to_uri_authority_string(&self) -> Cow<'_, str>;
 }

--- a/validators/src/traits/validate_signed_integer.rs
+++ b/validators/src/traits/validate_signed_integer.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)] // pointer widths intentional
 /// Validate and deserialize signed integers.
 pub trait ValidateSignedInteger: Sized {
     type Error;

--- a/validators/src/traits/validate_unsigned_integer.rs
+++ b/validators/src/traits/validate_unsigned_integer.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)] // pointer widths intentional
 /// Validate and deserialize unsigned integers.
 pub trait ValidateUnsignedInteger: Sized {
     type Error;

--- a/validators/tests/domain.rs
+++ b/validators/tests/domain.rs
@@ -186,6 +186,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*conflict(Allow)))]
                     pub struct DomainAllowPort {
@@ -193,6 +194,7 @@ fn basic() {
                         pub port: Option<u16>,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*port(Must), conflict(Allow)))]
                     pub struct DomainWithPort {
@@ -200,6 +202,7 @@ fn basic() {
                         pub port: u16,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*port(Disallow), conflict(Allow)))]
                     struct DomainWithoutPort(pub String);
@@ -223,6 +226,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*))]
                     pub struct DomainAllowIPv4AllowPortIsLocal {
@@ -232,6 +236,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*port(Must)))]
                     pub struct DomainAllowIPv4WithPortIsLocal {
@@ -241,6 +246,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*port(Disallow)))]
                     #[allow(dead_code)]
@@ -250,6 +256,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Must), conflict(Allow)))]
                     pub struct DomainIPv4AllowPortIsLocal {
@@ -258,6 +265,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Must), port(Must), conflict(Allow)))]
                     pub struct DomainIPv4WithPortIsLocal {
@@ -266,6 +274,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Must), port(Disallow), conflict(Allow)))]
                     #[allow(dead_code)]
@@ -274,6 +283,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Disallow)))]
                     pub struct DomainNonIPv4AllowPortIsLocal {
@@ -282,6 +292,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Disallow), port(Must)))]
                     pub struct DomainNonIPv4WithPortIsLocal {
@@ -290,6 +301,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(domain($($p($v),)*ipv4(Disallow), port(Disallow)))]
                     #[allow(dead_code)]

--- a/validators/tests/email.rs
+++ b/validators/tests/email.rs
@@ -191,6 +191,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow)))]
                     pub struct EmailAllowIP {
@@ -199,6 +200,7 @@ fn basic() {
                         pub domain_part: validators::models::Host,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow), ip(Must), conflict(Allow)))]
                     pub struct EmailIP {
@@ -207,6 +209,7 @@ fn basic() {
                         pub domain_part: std::net::IpAddr,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow), ip(Disallow)))]
                     pub struct EmailNonIP {
@@ -215,6 +218,7 @@ fn basic() {
                         pub domain_part: String,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*))]
                     pub struct EmailAllowCommentAllowIP {
@@ -227,6 +231,7 @@ fn basic() {
                         pub comment_after_domain_part: Option<String>,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*ip(Must), conflict(Allow)))]
                     pub struct EmailAllowCommentIP {
@@ -239,6 +244,7 @@ fn basic() {
                         pub comment_after_domain_part: Option<String>,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*ip(Disallow)))]
                     pub struct EmailAllowCommentNonIP {
@@ -273,6 +279,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow)))]
                     pub struct EmailAllowIPIsLocal {
@@ -282,6 +289,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow), ip(Must), conflict(Allow)))]
                     pub struct EmailIPIsLocal {
@@ -291,6 +299,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*comment(Disallow), ip(Disallow)))]
                     pub struct EmailNonIPIsLocal {
@@ -300,6 +309,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*))]
                     pub struct EmailAllowCommentAllowIPIsLocal {
@@ -313,6 +323,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*ip(Must), conflict(Allow)))]
                     pub struct EmailAllowCommentIPIsLocal {
@@ -326,6 +337,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(email($($p($v),)*ip(Disallow)))]
                     pub struct EmailAllowCommentNonIPIsLocal {

--- a/validators/tests/host.rs
+++ b/validators/tests/host.rs
@@ -128,6 +128,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*))]
                     pub struct HostAllowPort {
@@ -135,6 +136,7 @@ fn basic() {
                         pub port: Option<u16>,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*port(Must)))]
                     pub struct HostWithPort {
@@ -142,6 +144,7 @@ fn basic() {
                         pub port: u16,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*port(Disallow)))]
                     pub struct HostWithoutPort(pub validators::models::Host);
@@ -165,6 +168,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*))]
                     pub struct HostAllowPortIsLocal {
@@ -173,6 +177,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*port(Must)))]
                     pub struct HostWithPortIsLocal {
@@ -181,6 +186,7 @@ fn basic() {
                         pub is_local: bool,
                     }
 
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(host($($p($v),)*port(Disallow)))]
                     pub struct HostWithoutPortIsLocal {

--- a/validators/tests/http_ftp_url.rs
+++ b/validators/tests/http_ftp_url.rs
@@ -8,6 +8,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(http_ftp_url($($p($v),)*))]
                     pub struct Validator {

--- a/validators/tests/http_url.rs
+++ b/validators/tests/http_url.rs
@@ -8,6 +8,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(http_url($($p($v),)*))]
                     pub struct Validator {

--- a/validators/tests/signed_integer.rs
+++ b/validators/tests/signed_integer.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)] // target_pointer_widths are deliberate
 #![cfg(all(feature = "test", feature = "derive", feature = "signed_integer"))]
 
 use validators::prelude::{validators_prelude::RangeOption, *};
@@ -108,6 +109,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(signed_integer($($p($v),)*))]
                     pub struct I8(i8);
@@ -129,6 +131,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(signed_integer($($p($v),)*))]
                     pub struct Isize(isize);
@@ -150,6 +153,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(signed_integer($($p($v),)*))]
                     pub struct I128(i128);

--- a/validators/tests/unsigned_integer.rs
+++ b/validators/tests/unsigned_integer.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)] // target_pointer_width options are deliberate
 #![cfg(all(feature = "test", feature = "derive", feature = "unsigned_integer"))]
 
 use validators::prelude::{validators_prelude::RangeOption, *};
@@ -107,6 +108,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(unsigned_integer($($p($v),)*))]
                     pub struct U8(u8);
@@ -128,6 +130,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(unsigned_integer($($p($v),)*))]
                     pub struct Usize(usize);
@@ -149,6 +152,7 @@ fn basic() {
         ($( { $( $p:meta => $v:meta ),* $(,)* } ),* $(,)* ) => {
             $(
                 {
+                    #[allow(dead_code)] // ignore spurious dead code
                     #[derive(Validator)]
                     #[validator(unsigned_integer($($p($v),)*))]
                     pub struct U128(u128);


### PR DESCRIPTION
Hello, @magiclen!

This PR updates the dependencies to bring idna to 1.0.3 to avoid CVE-2024-12224, resolving #5. In order to also not break CI, I have rolled up PR #6 and ignored the clippy warnings that seemed to be spurious given my reading of the intent of the code. Feel free to revert those specific commits as needed. I will also create a PR for [rocket-recaptcha-v3](https://github.com/magiclen/rocket-recaptcha-v3) to pull this downstream. Let me know if any concerns.

Cheers,
Mautamu


fixes: #5